### PR TITLE
.travis.yml does not cache dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ script: "mvn clean package -Dmaven.test.skip=true"
 notifications:
   email:
     - rememberber@163.com
+cache:
+  directories:
+  - $HOME/.m2


### PR DESCRIPTION
Travis CI can cache content that does not often change, to speed up your build process.