### PR TITLE
Host功能查找按钮的提示文本错误修正

### DIFF
--- a/src/main/java/com/luoboduner/moo/tool/ui/form/func/HostForm.form
+++ b/src/main/java/com/luoboduner/moo/tool/ui/form/func/HostForm.form
@@ -114,7 +114,7 @@
                     <properties>
                       <icon value="icon/find_dark.png"/>
                       <text value=""/>
-                      <toolTipText value="新建(Ctrl+N)"/>
+                      <toolTipText value="查找(Ctrl+F)"/>
                     </properties>
                   </component>
                   <component id="1901b" class="javax.swing.JButton" binding="exportButton">


### PR DESCRIPTION
Host功能页面的查找按钮的提示文本错误（Ctrl+N）修改为（Ctrl+F）