### PR TITLE
Unified favorite icon

### DIFF
--- a/src/main/java/com/luoboduner/moo/tool/ui/component/CustomizeIcon.java
+++ b/src/main/java/com/luoboduner/moo/tool/ui/component/CustomizeIcon.java
@@ -1,0 +1,19 @@
+package com.luoboduner.moo.tool.ui.component;
+
+import com.formdev.flatlaf.extras.FlatSVGIcon;
+
+/**
+ * <pre>
+ * 自定义Icon
+ * </pre>
+ *
+ * @author <a href="https://github.com/smallclover">smallclover</a>
+ * @since 2023/09/12.
+ */
+public class CustomizeIcon {
+
+    // 收藏夹
+    public static FlatSVGIcon favoriteBookBtnIcon = new FlatSVGIcon("icon/favorite-filling.svg");
+    // 收藏
+    public static FlatSVGIcon favoriteBtnIcon = new FlatSVGIcon("icon/favorite.svg");
+}

--- a/src/main/java/com/luoboduner/moo/tool/ui/form/func/ColorBoardForm.java
+++ b/src/main/java/com/luoboduner/moo/tool/ui/form/func/ColorBoardForm.java
@@ -7,6 +7,7 @@ import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.uiDesigner.core.Spacer;
 import com.luoboduner.moo.tool.App;
+import com.luoboduner.moo.tool.ui.component.CustomizeIcon;
 import com.luoboduner.moo.tool.ui.listener.func.ColorBoardListener;
 import com.luoboduner.moo.tool.util.ColorUtil;
 import com.luoboduner.moo.tool.util.UndoUtil;
@@ -88,8 +89,8 @@ public class ColorBoardForm {
         colorBoardForm.getCodeTypeComboBox().setSelectedItem(App.config.getColorCodeType());
         colorBoardForm.getThemeComboBox().setSelectedItem(App.config.getColorTheme());
 
-        colorBoardForm.getFavoriteBookButton().setIcon(new FlatSVGIcon("icon/favorite-filling.svg"));
-        colorBoardForm.getFavoriteButton().setIcon(new FlatSVGIcon("icon/favorite.svg"));
+        colorBoardForm.getFavoriteBookButton().setIcon(CustomizeIcon.favoriteBookBtnIcon);
+        colorBoardForm.getFavoriteButton().setIcon(CustomizeIcon.favoriteBtnIcon);
         colorBoardForm.getPickerButton().setIcon(new FlatSVGIcon("icon/color_picker.svg"));
         colorBoardForm.getCopyButton().setIcon(new FlatSVGIcon("icon/copy.svg"));
         colorBoardForm.getChooseColorButton().setIcon(new FlatSVGIcon("icon/color.svg"));

--- a/src/main/java/com/luoboduner/moo/tool/ui/form/func/CronForm.form
+++ b/src/main/java/com/luoboduner/moo/tool/ui/form/func/CronForm.form
@@ -3123,8 +3123,7 @@
                           <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
-                          <icon value="icon/favorite.png"/>
-                          <text value=""/>
+                          <text value="收藏"/>
                         </properties>
                       </component>
                     </children>

--- a/src/main/java/com/luoboduner/moo/tool/ui/form/func/CronForm.java
+++ b/src/main/java/com/luoboduner/moo/tool/ui/form/func/CronForm.java
@@ -9,6 +9,7 @@ import com.intellij.uiDesigner.core.GridLayoutManager;
 import com.intellij.uiDesigner.core.Spacer;
 import com.luoboduner.moo.tool.App;
 import com.luoboduner.moo.tool.ui.Style;
+import com.luoboduner.moo.tool.ui.component.CustomizeIcon;
 import com.luoboduner.moo.tool.ui.listener.func.CronListener;
 import com.luoboduner.moo.tool.util.UndoUtil;
 import lombok.Getter;
@@ -321,8 +322,8 @@ public class CronForm {
     }
 
     private static void initUi() {
-        cronForm.getAddToFavoriteButton().setIcon(new FlatSVGIcon("icon/favorite.svg"));
-
+        cronForm.getAddToFavoriteButton().setIcon(CustomizeIcon.favoriteBtnIcon);
+        cronForm.getFavoriteBookButton().setIcon(CustomizeIcon.favoriteBookBtnIcon);
         cronForm.getSplitPane().setDividerLocation((int) (App.mainFrame.getWidth() / 2));
         cronForm.getNextExecutionTimeTextArea().setText("最近10次运行时间：");
 
@@ -1816,8 +1817,7 @@ public class CronForm {
         favoriteBookButton.setText("收藏夹");
         panel52.add(favoriteBookButton, new GridConstraints(0, 3, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         addToFavoriteButton = new JButton();
-        addToFavoriteButton.setIcon(new ImageIcon(getClass().getResource("/icon/favorite.png")));
-        addToFavoriteButton.setText("");
+        addToFavoriteButton.setText("收藏");
         panel52.add(addToFavoriteButton, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         final JPanel panel53 = new JPanel();
         panel53.setLayout(new GridLayoutManager(1, 1, new Insets(0, 0, 0, 0), -1, -1));

--- a/src/main/java/com/luoboduner/moo/tool/ui/form/func/RegexForm.form
+++ b/src/main/java/com/luoboduner/moo/tool/ui/form/func/RegexForm.form
@@ -70,8 +70,7 @@
                           <grid row="0" column="2" row-span="1" col-span="1" vsize-policy="0" hsize-policy="3" anchor="0" fill="1" indent="0" use-parent-layout="false"/>
                         </constraints>
                         <properties>
-                          <icon value="icon/favorite.png"/>
-                          <text value=""/>
+                          <text value="收藏"/>
                         </properties>
                       </component>
                       <component id="8d1c7" class="javax.swing.JButton" binding="matchTestButton">

--- a/src/main/java/com/luoboduner/moo/tool/ui/form/func/RegexForm.java
+++ b/src/main/java/com/luoboduner/moo/tool/ui/form/func/RegexForm.java
@@ -11,6 +11,7 @@ import com.luoboduner.moo.tool.App;
 import com.luoboduner.moo.tool.dao.TFuncContentMapper;
 import com.luoboduner.moo.tool.domain.TFuncContent;
 import com.luoboduner.moo.tool.ui.FuncConsts;
+import com.luoboduner.moo.tool.ui.component.CustomizeIcon;
 import com.luoboduner.moo.tool.ui.component.RegexSyntaxTextViewer;
 import com.luoboduner.moo.tool.ui.listener.func.RegexListener;
 import com.luoboduner.moo.tool.util.MybatisUtil;
@@ -183,7 +184,8 @@ public class RegexForm {
     }
 
     private static void initUi() {
-        regexForm.getAddToFavoriteButton().setIcon(new FlatSVGIcon("icon/favorite.svg"));
+        regexForm.getAddToFavoriteButton().setIcon(CustomizeIcon.favoriteBtnIcon);
+        regexForm.getFavoriteBookButton().setIcon(CustomizeIcon.favoriteBookBtnIcon);
         regexForm.getRegexPanel().updateUI();
 
         ScrollUtil.smoothPane(regexForm.getCommonRegexScrollPane());
@@ -247,8 +249,7 @@ public class RegexForm {
         favoriteBookButton.setText("收藏夹");
         panel3.add(favoriteBookButton, new GridConstraints(0, 4, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         addToFavoriteButton = new JButton();
-        addToFavoriteButton.setIcon(new ImageIcon(getClass().getResource("/icon/favorite.png")));
-        addToFavoriteButton.setText("");
+        addToFavoriteButton.setText("收藏");
         panel3.add(addToFavoriteButton, new GridConstraints(0, 2, 1, 1, GridConstraints.ANCHOR_CENTER, GridConstraints.FILL_HORIZONTAL, GridConstraints.SIZEPOLICY_CAN_SHRINK | GridConstraints.SIZEPOLICY_CAN_GROW, GridConstraints.SIZEPOLICY_FIXED, null, null, null, 0, false));
         matchTestButton = new JButton();
         matchTestButton.setText("匹配测试");


### PR DESCRIPTION
## 问题：收藏按钮图标不一致

###  Cron
![2023-09-12-10-44-51-image](https://github.com/rememberber/MooTool/assets/10950966/823194b2-26f1-4073-b738-287c8b5c0928)

### 正则
![2023-09-12-10-45-07-image](https://github.com/rememberber/MooTool/assets/10950966/6be32c1f-f909-4eb6-9eff-57f485f51d7e)

### 调色板
![2023-09-12-10-45-21-image](https://github.com/rememberber/MooTool/assets/10950966/ac402b9d-c46d-4372-94e2-89a6aac58af4)

## 实现

> 1. 统一改成调色板的收藏样式，比较符合整体的UI风格
> 2. 将自定义的Icon统一到一处进行管理，有利于代码的整洁
```java
public class CustomizeIcon {

    // 收藏夹
    public static FlatSVGIcon favoriteBookBtnIcon = new FlatSVGIcon("icon/favorite-filling.svg");
    // 收藏
    public static FlatSVGIcon favoriteBtnIcon = new FlatSVGIcon("icon/favorite.svg");
}

```

```java
  private static void initUi() {
      regexForm.getAddToFavoriteButton().setIcon(CustomizeIcon.favoriteBtnIcon);
      regexForm.getFavoriteBookButton().setIcon(CustomizeIcon.favoriteBookBtnIcon);
  }

````

## 修改后

### Cron
![image](https://github.com/rememberber/MooTool/assets/10950966/e6f8f0bf-91da-4559-be47-3e7b754626cf)

###  正则
![image](https://github.com/rememberber/MooTool/assets/10950966/2b126df4-4b8b-4255-93e6-9ae7f25fc777)


