### PR TITLE
fix: 支持 Apple Silicon macOS 安装包选择

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,5 @@ build/
 
 
 logs/
+.codegraph/
+.cursor/

--- a/pom.xml
+++ b/pom.xml
@@ -56,6 +56,9 @@
         <tika.version>3.0.0</tika.version>
         <jackson-databind.version>2.13.3</jackson-databind.version>
         <java-diff.version>4.16</java-diff.version>
+        <mac.outputDirectory>${project.build.directory}</mac.outputDirectory>
+        <mac.startup>UNIVERSAL</mac.startup>
+        <mac.jdkPath>${java.home}</mac.jdkPath>
     </properties>
 
     <repositories>
@@ -76,6 +79,25 @@
             <url>http://maven.aliyun.com/nexus/content/groups/public/</url>
         </repository>
     </repositories>
+
+    <profiles>
+        <profile>
+            <id>mac-intel</id>
+            <properties>
+                <mac.outputDirectory>${project.build.directory}/mac-intel</mac.outputDirectory>
+                <mac.startup>X86_64</mac.startup>
+                <mac.jdkPath>${env.MACOS_INTEL_JDK}</mac.jdkPath>
+            </properties>
+        </profile>
+        <profile>
+            <id>mac-apple-silicon</id>
+            <properties>
+                <mac.outputDirectory>${project.build.directory}/mac-apple-silicon</mac.outputDirectory>
+                <mac.startup>ARM64</mac.startup>
+                <mac.jdkPath>${env.MACOS_APPLE_SILICON_JDK}</mac.jdkPath>
+            </properties>
+        </profile>
+    </profiles>
 
     <dependencies>
 
@@ -412,7 +434,10 @@
                 <artifactId>javapackager</artifactId>
                 <version>1.7.5</version>
                 <configuration>
+                    <outputDirectory>${mac.outputDirectory}</outputDirectory>
+                    <displayName>${project.name}</displayName>
                     <bundleJre>true</bundleJre>
+                    <jdkPath>${mac.jdkPath}</jdkPath>
                     <mainClass>com.luoboduner.moo.tool.App</mainClass>
                     <generateInstaller>true</generateInstaller>
                     <!-- 这行不能被格式化为多行，否则会出错-->
@@ -478,7 +503,7 @@
                             <platform>mac</platform>
                             <createTarball>true</createTarball>
                             <macConfig>
-                                <macStartup>UNIVERSAL</macStartup>
+                                <macStartup>${mac.startup}</macStartup>
 <!--                                <developerId>rememberber@163.com</developerId>-->
                             </macConfig>
                             <additionalModules>jdk.crypto.ec,jdk.charsets</additionalModules>

--- a/readme.md
+++ b/readme.md
@@ -312,6 +312,32 @@ Windows • Linux • macOS
 [iconfont](https://www.iconfont.cn/)
 
 ## 开发温馨提示
-最低JDK版本要求：**17**  
+最低JDK版本要求：**21**  
 在你开始开发之前, **请按下图设置IntelliJ IDEA**, 然后 **maven clean**:
 ![considerations](assets/material/gui_build.png)
+
+### macOS打包
+
+默认打包使用当前运行 Maven 的 JDK：
+
+```bash
+mvn clean package -Dmaven.test.skip=true
+```
+
+Intel 芯片包需要使用 x86_64 JDK 21：
+
+```bash
+MACOS_INTEL_JDK=/path/to/jdk-21-x86_64 mvn -Pmac-intel clean package -Dmaven.test.skip=true
+```
+
+Apple Silicon 包需要使用 arm64/aarch64 JDK 21：
+
+```bash
+MACOS_APPLE_SILICON_JDK=/path/to/jdk-21-aarch64 mvn -Pmac-apple-silicon clean package -Dmaven.test.skip=true
+```
+
+对应产物目录：
+
+- 默认包：`target/`
+- Intel 包：`target/mac-intel/`
+- Apple Silicon 包：`target/mac-apple-silicon/`

--- a/src/main/java/com/luoboduner/moo/tool/ui/dialog/UpdateDialog.java
+++ b/src/main/java/com/luoboduner/moo/tool/ui/dialog/UpdateDialog.java
@@ -13,6 +13,7 @@ import com.jayway.jsonpath.JsonPath;
 import com.luoboduner.moo.tool.App;
 import com.luoboduner.moo.tool.ui.UiConsts;
 import com.luoboduner.moo.tool.util.ComponentUtil;
+import com.luoboduner.moo.tool.util.DownloadLinkSelector;
 import com.luoboduner.moo.tool.util.SystemUtil;
 import org.apache.commons.lang3.StringUtils;
 
@@ -102,15 +103,7 @@ public class UpdateDialog extends JDialog {
                         return;
                     } else {
                         DocumentContext parse = JsonPath.parse(downloadLinkInfo);
-                        if (SystemUtil.isWindowsOs()) {
-                            fileUrl = parse.read("$.windows");
-                        } else if (SystemUtil.isMacOs()) {
-                            fileUrl = parse.read("$.mac");
-                        } else if (SystemUtil.isMacSilicon()) {
-                            fileUrl = parse.read("$.macSilicon");
-                        } else if (SystemUtil.isLinuxOs()) {
-                            fileUrl = parse.read("$.linux");
-                        }
+                        fileUrl = DownloadLinkSelector.select(parse);
                     }
 
                     String fileName = FileUtil.getName(fileUrl);

--- a/src/main/java/com/luoboduner/moo/tool/util/DownloadLinkSelector.java
+++ b/src/main/java/com/luoboduner/moo/tool/util/DownloadLinkSelector.java
@@ -1,0 +1,46 @@
+package com.luoboduner.moo.tool.util;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.PathNotFoundException;
+import org.apache.commons.lang3.StringUtils;
+
+public class DownloadLinkSelector {
+
+    public static String select(DocumentContext links) {
+        return select(System.getProperty("os.name"), System.getProperty("os.arch"), links);
+    }
+
+    static String select(String osName, String osArch, DocumentContext links) {
+        if (contains(osName, "Windows")) {
+            return links.read("$.windows");
+        }
+
+        if (contains(osName, "Mac")) {
+            if ("aarch64".equals(osArch)) {
+                String appleSiliconLink = readOptional(links, "$.macSilicon");
+                if (StringUtils.isNotEmpty(appleSiliconLink)) {
+                    return appleSiliconLink;
+                }
+            }
+            return links.read("$.mac");
+        }
+
+        if (contains(osName, "Linux")) {
+            return links.read("$.linux");
+        }
+
+        return "";
+    }
+
+    private static boolean contains(String value, String searchText) {
+        return value != null && value.contains(searchText);
+    }
+
+    private static String readOptional(DocumentContext links, String path) {
+        try {
+            return links.read(path);
+        } catch (PathNotFoundException e) {
+            return "";
+        }
+    }
+}

--- a/src/test/java/com/luoboduner/moo/tool/util/DownloadLinkSelectorTest.java
+++ b/src/test/java/com/luoboduner/moo/tool/util/DownloadLinkSelectorTest.java
@@ -1,0 +1,44 @@
+package com.luoboduner.moo.tool.util;
+
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class DownloadLinkSelectorTest {
+
+    @Test
+    public void selectsAppleSiliconDownloadBeforeGenericMacDownload() {
+        DocumentContext links = JsonPath.parse("{"
+                + "\"mac\":\"https://example.com/MooTool.dmg\","
+                + "\"macSilicon\":\"https://example.com/MooTool-AppleSilicon.dmg\""
+                + "}");
+
+        String selected = DownloadLinkSelector.select("Mac OS X", "aarch64", links);
+
+        Assert.assertEquals("https://example.com/MooTool-AppleSilicon.dmg", selected);
+    }
+
+    @Test
+    public void fallsBackToGenericMacDownloadWhenAppleSiliconDownloadIsMissing() {
+        DocumentContext links = JsonPath.parse("{"
+                + "\"mac\":\"https://example.com/MooTool.dmg\""
+                + "}");
+
+        String selected = DownloadLinkSelector.select("Mac OS X", "aarch64", links);
+
+        Assert.assertEquals("https://example.com/MooTool.dmg", selected);
+    }
+
+    @Test
+    public void selectsGenericMacDownloadForIntelMac() {
+        DocumentContext links = JsonPath.parse("{"
+                + "\"mac\":\"https://example.com/MooTool.dmg\","
+                + "\"macSilicon\":\"https://example.com/MooTool-AppleSilicon.dmg\""
+                + "}");
+
+        String selected = DownloadLinkSelector.select("Mac OS X", "x86_64", links);
+
+        Assert.assertEquals("https://example.com/MooTool.dmg", selected);
+    }
+}


### PR DESCRIPTION
## 变更说明

- 修复 macOS Apple Silicon 设备更新下载链接选择问题：优先使用 `macSilicon` 下载地址，缺失时再回退到通用 `mac` 下载地址。
- 增加 macOS Intel 和 Apple Silicon 两个打包 profile，分别输出到独立目录，便于同时构建不同架构安装包。
- 更新 README 中的 JDK 版本要求和 macOS 打包命令说明。
- 将本地工具目录 `.codegraph/` 和 `.cursor/` 加入 `.gitignore`。

## 验证

- `mvn -Dtest=DownloadLinkSelectorTest test`
- `mvn package -Dmaven.test.skip=true`
- `MACOS_APPLE_SILICON_JDK=/Users/huapai/.sdkman/candidates/java/21.0.10-oracle mvn -Pmac-apple-silicon package -Dmaven.test.skip=true`
