### PR TITLE
fix: 修复多屏环境下托盘菜单定位异常

### DIFF
--- a/src/main/java/com/luoboduner/moo/tool/ui/component/JPopupMenuMouseAdapter.java
+++ b/src/main/java/com/luoboduner/moo/tool/ui/component/JPopupMenuMouseAdapter.java
@@ -53,10 +53,36 @@ public class JPopupMenuMouseAdapter extends MouseAdapter {
     private void maybeShowPopup(MouseEvent e) {
         if (e.isPopupTrigger()) {
             Dimension size = popupMenu.getPreferredSize();
-            popupMenu.setLocation(e.getX() - size.width, e.getY() - size.height);
+            Point mousePoint = new Point(e.getXOnScreen(), e.getYOnScreen());
+            Point popupLocation = calculatePopupLocation(mousePoint, size, getScreenBounds(mousePoint));
+            popupMenu.setLocation(popupLocation);
             popupMenu.setInvoker(popupMenu);
             popupMenu.setVisible(true);
         }
+    }
+
+    static Point calculatePopupLocation(Point mousePoint, Dimension popupSize, Rectangle screenBounds) {
+        int x = mousePoint.x - popupSize.width;
+        int y = mousePoint.y - popupSize.height;
+
+        int maxX = Math.max(screenBounds.x, screenBounds.x + screenBounds.width - popupSize.width);
+        int maxY = Math.max(screenBounds.y, screenBounds.y + screenBounds.height - popupSize.height);
+
+        x = Math.max(screenBounds.x, Math.min(x, maxX));
+        y = Math.max(screenBounds.y, Math.min(y, maxY));
+
+        return new Point(x, y);
+    }
+
+    private static Rectangle getScreenBounds(Point point) {
+        GraphicsEnvironment graphicsEnvironment = GraphicsEnvironment.getLocalGraphicsEnvironment();
+        for (GraphicsDevice screenDevice : graphicsEnvironment.getScreenDevices()) {
+            Rectangle bounds = screenDevice.getDefaultConfiguration().getBounds();
+            if (bounds.contains(point)) {
+                return bounds;
+            }
+        }
+        return graphicsEnvironment.getDefaultScreenDevice().getDefaultConfiguration().getBounds();
     }
 
     public static void showMainFrame() {

--- a/src/test/java/com/luoboduner/moo/tool/ui/component/JPopupMenuMouseAdapterTest.java
+++ b/src/test/java/com/luoboduner/moo/tool/ui/component/JPopupMenuMouseAdapterTest.java
@@ -1,0 +1,42 @@
+package com.luoboduner.moo.tool.ui.component;
+
+import org.junit.Test;
+
+import java.awt.Dimension;
+import java.awt.Point;
+import java.awt.Rectangle;
+
+import static org.junit.Assert.assertEquals;
+
+public class JPopupMenuMouseAdapterTest {
+
+    @Test
+    public void calculatePopupLocationUsesAbsoluteCoordinatesOnSecondaryScreen() {
+        Point location = JPopupMenuMouseAdapter.calculatePopupLocation(
+                new Point(2500, 1040),
+                new Dimension(180, 120),
+                new Rectangle(1920, 0, 1920, 1080));
+
+        assertEquals(new Point(2320, 920), location);
+    }
+
+    @Test
+    public void calculatePopupLocationKeepsPopupInScreenWithNegativeOrigin() {
+        Point location = JPopupMenuMouseAdapter.calculatePopupLocation(
+                new Point(-10, 1040),
+                new Dimension(180, 120),
+                new Rectangle(-1920, 0, 1920, 1080));
+
+        assertEquals(new Point(-190, 920), location);
+    }
+
+    @Test
+    public void calculatePopupLocationClampsToCurrentScreenBounds() {
+        Point location = JPopupMenuMouseAdapter.calculatePopupLocation(
+                new Point(1930, 10),
+                new Dimension(180, 120),
+                new Rectangle(1920, 0, 1920, 1080));
+
+        assertEquals(new Point(1920, 0), location);
+    }
+}


### PR DESCRIPTION
## 变更说明
- 修复托盘右键菜单定位逻辑，改用屏幕绝对坐标，避免多屏环境下菜单出现在错误显示器。
- 根据触发点所在显示器的边界限制菜单位置，兼容右侧副屏和左侧负坐标副屏。
- 补充多屏菜单定位的回归单元测试。

Fixes #180

## 测试
- JAVA_HOME=/Users/huapai/Library/Java/JavaVirtualMachines/corretto-21.0.8/Contents/Home PATH="$JAVA_HOME/bin:$PATH" mvnd test
- 结果：Tests run: 7, Failures: 0, Errors: 0, Skipped: 0，BUILD SUCCESS