### PR TITLE
修复 Ctrl+Z 撤销异常

### DIFF
--- a/src/main/java/com/luoboduner/moo/tool/util/UndoUtil.java
+++ b/src/main/java/com/luoboduner/moo/tool/util/UndoUtil.java
@@ -6,7 +6,7 @@ import org.fife.ui.rsyntaxtextarea.RSyntaxTextArea;
 import javax.swing.text.JTextComponent;
 import javax.swing.undo.UndoManager;
 import java.awt.event.KeyEvent;
-import java.awt.event.KeyListener;
+import java.awt.event.KeyAdapter;
 import java.lang.reflect.Field;
 
 /**
@@ -26,6 +26,10 @@ public class UndoUtil {
      * @param object
      */
     public static void register(Object object) {
+        if (object instanceof JTextComponent) {
+            registerTextComponent((JTextComponent) object);
+            return;
+        }
         Class strClass = object.getClass();
         Field[] declaredFields = strClass.getDeclaredFields();
         for (Field field : declaredFields) {
@@ -33,37 +37,38 @@ public class UndoUtil {
                 if (RSyntaxTextArea.class.isAssignableFrom(field.getType())) {
                     continue;
                 }
-                UndoManager undoManager = new UndoManager();
                 try {
                     field.setAccessible(true);
-                    ((JTextComponent) field.get(object)).getDocument().addUndoableEditListener(undoManager);
-                    ((JTextComponent) field.get(object)).addKeyListener(new KeyListener() {
-                        @Override
-                        public void keyReleased(KeyEvent arg0) {
-                        }
-
-                        @Override
-                        public void keyPressed(KeyEvent evt) {
-                            if ((evt.isControlDown() || evt.isMetaDown()) && evt.getKeyCode() == KeyEvent.VK_Z) {
-                                if (undoManager.canUndo()) {
-                                    undoManager.undo();
-                                }
-                            }
-                            if ((evt.isControlDown() || evt.isMetaDown()) && evt.getKeyCode() == KeyEvent.VK_Y) {
-                                if (undoManager.canRedo()) {
-                                    undoManager.redo();
-                                }
-                            }
-                        }
-
-                        @Override
-                        public void keyTyped(KeyEvent arg0) {
-                        }
-                    });
+                    registerTextComponent((JTextComponent) field.get(object));
                 } catch (IllegalAccessException e) {
                     log.error(e.toString());
                 }
             }
         }
+    }
+
+    private static void registerTextComponent(JTextComponent textComponent) {
+        if (textComponent == null) {
+            return;
+        }
+        UndoManager undoManager = new UndoManager();
+        textComponent.getDocument().addUndoableEditListener(undoManager);
+        textComponent.addKeyListener(new KeyAdapter() {
+            @Override
+            public void keyPressed(KeyEvent evt) {
+                if ((evt.isControlDown() || evt.isMetaDown()) && evt.getKeyCode() == KeyEvent.VK_Z) {
+                    if (undoManager.canUndo()) {
+                        undoManager.undo();
+                    }
+                    evt.consume();
+                }
+                if ((evt.isControlDown() || evt.isMetaDown()) && evt.getKeyCode() == KeyEvent.VK_Y) {
+                    if (undoManager.canRedo()) {
+                        undoManager.redo();
+                    }
+                    evt.consume();
+                }
+            }
+        });
     }
 }

--- a/src/test/java/com/luoboduner/moo/tool/util/UndoUtilTest.java
+++ b/src/test/java/com/luoboduner/moo/tool/util/UndoUtilTest.java
@@ -1,0 +1,51 @@
+package com.luoboduner.moo.tool.util;
+
+import org.junit.Test;
+
+import javax.swing.JTextArea;
+import java.awt.event.KeyEvent;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class UndoUtilTest {
+
+    @Test
+    public void ctrlZUndoConsumesEvent() {
+        JTextArea textArea = new JTextArea();
+        TextAreaHolder holder = new TextAreaHolder(textArea);
+        UndoUtil.register(holder);
+        textArea.setText("before");
+        textArea.append(" after");
+
+        KeyEvent ctrlZ = new KeyEvent(textArea, KeyEvent.KEY_PRESSED, System.currentTimeMillis(),
+                KeyEvent.CTRL_DOWN_MASK, KeyEvent.VK_Z, KeyEvent.CHAR_UNDEFINED);
+        textArea.getKeyListeners()[0].keyPressed(ctrlZ);
+
+        assertEquals("before", textArea.getText());
+        assertTrue(ctrlZ.isConsumed());
+    }
+
+    @Test
+    public void directTextComponentCanBeRegistered() {
+        JTextArea textArea = new JTextArea();
+        UndoUtil.register(textArea);
+        textArea.setText("before");
+        textArea.append(" after");
+
+        KeyEvent ctrlZ = new KeyEvent(textArea, KeyEvent.KEY_PRESSED, System.currentTimeMillis(),
+                KeyEvent.CTRL_DOWN_MASK, KeyEvent.VK_Z, KeyEvent.CHAR_UNDEFINED);
+        textArea.getKeyListeners()[0].keyPressed(ctrlZ);
+
+        assertEquals("before", textArea.getText());
+        assertTrue(ctrlZ.isConsumed());
+    }
+
+    private static class TextAreaHolder {
+        private final JTextArea textArea;
+
+        private TextAreaHolder(JTextArea textArea) {
+            this.textArea = textArea;
+        }
+    }
+}


### PR DESCRIPTION
## 修复内容

- 修复 Ctrl+Z / Ctrl+Y 执行撤销或重做后未消费快捷键事件的问题
- 支持直接对 JTextComponent 调用 UndoUtil.register 注册撤销监听
- 补充 UndoUtil 的 Ctrl+Z 回归测试

## 验证

```bash
JAVA_HOME=/Users/huapai/Library/Java/JavaVirtualMachines/corretto-21.0.8/Contents/Home PATH=/Users/huapai/.local/share/mise/installs/maven/3.6.3/apache-maven-3.6.3/bin:$JAVA_HOME/bin:$PATH mvn -Dtest=UndoUtilTest test
```

结果：Tests run: 2, Failures: 0, Errors: 0, Skipped: 0。

Closes #181