### PR TITLE
feat: 支持 Linux Cron 表达式

### DIFF
--- a/src/main/java/com/luoboduner/moo/tool/ui/dialog/FavoriteCronDialog.java
+++ b/src/main/java/com/luoboduner/moo/tool/ui/dialog/FavoriteCronDialog.java
@@ -1,10 +1,5 @@
 package com.luoboduner.moo.tool.ui.dialog;
 
-import com.cronutils.descriptor.CronDescriptor;
-import com.cronutils.model.CronType;
-import com.cronutils.model.definition.CronDefinition;
-import com.cronutils.model.definition.CronDefinitionBuilder;
-import com.cronutils.parser.CronParser;
 import com.formdev.flatlaf.util.SystemInfo;
 import com.intellij.uiDesigner.core.GridConstraints;
 import com.intellij.uiDesigner.core.GridLayoutManager;
@@ -18,6 +13,7 @@ import com.luoboduner.moo.tool.ui.form.MainWindow;
 import com.luoboduner.moo.tool.ui.form.func.CronForm;
 import com.luoboduner.moo.tool.ui.form.func.FavoriteCronForm;
 import com.luoboduner.moo.tool.util.ComponentUtil;
+import com.luoboduner.moo.tool.util.CronExpressionUtil;
 import com.luoboduner.moo.tool.util.MybatisUtil;
 import com.luoboduner.moo.tool.util.SqliteUtil;
 import com.luoboduner.moo.tool.util.SystemUtil;
@@ -157,10 +153,7 @@ public class FavoriteCronDialog extends JDialog {
                 default -> {
                 }
             }
-            CronDescriptor descriptor = CronDescriptor.instance(selectedLocale);
-            CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
-            CronParser parser = new CronParser(cronDefinition);
-            String description = descriptor.describe(parser.parse(cron));
+            String description = CronExpressionUtil.describe(cron, selectedLocale);
 
             nameTextField.setText(description);
         } catch (Exception e) {

--- a/src/main/java/com/luoboduner/moo/tool/ui/listener/func/CronListener.java
+++ b/src/main/java/com/luoboduner/moo/tool/ui/listener/func/CronListener.java
@@ -3,28 +3,20 @@ package com.luoboduner.moo.tool.ui.listener.func;
 import cn.hutool.core.date.DateUtil;
 import cn.hutool.log.Log;
 import cn.hutool.log.LogFactory;
-import com.cronutils.descriptor.CronDescriptor;
-import com.cronutils.model.CronType;
-import com.cronutils.model.definition.CronDefinition;
-import com.cronutils.model.definition.CronDefinitionBuilder;
-import com.cronutils.model.time.ExecutionTime;
-import com.cronutils.parser.CronParser;
-import com.google.common.collect.Lists;
 import com.luoboduner.moo.tool.App;
 import com.luoboduner.moo.tool.ui.dialog.CommonCronDialog;
 import com.luoboduner.moo.tool.ui.dialog.FavoriteCronDialog;
 import com.luoboduner.moo.tool.ui.form.func.CronForm;
 import com.luoboduner.moo.tool.ui.frame.FavoriteCronFrame;
+import com.luoboduner.moo.tool.util.CronExpressionUtil;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 
 import javax.swing.*;
 import javax.swing.event.DocumentEvent;
 import java.awt.event.ActionListener;
-import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.Locale;
-import java.util.Optional;
 
 /**
  * <pre>
@@ -54,10 +46,7 @@ public class CronListener {
                     default -> {
                     }
                 }
-                CronDescriptor descriptor = CronDescriptor.instance(selectedLocale);
-                CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
-                CronParser parser = new CronParser(cronDefinition);
-                String description = descriptor.describe(parser.parse(cronExpression));
+                String description = CronExpressionUtil.describe(cronExpression, selectedLocale);
 
                 cronForm.getHumanReadableTextField().setText(description);
             } catch (Exception ex) {
@@ -102,23 +91,12 @@ public class CronListener {
                 try {
                     String cronExpression = cronForm.getCronExpressionTextField().getText();
 
-                    CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(CronType.QUARTZ);
-                    CronParser parser = new CronParser(cronDefinition);
-
                     // 获取未来10次运行时间：
-                    List<String> nextExecutionTimes = Lists.newArrayList();
-                    ExecutionTime executionTime = ExecutionTime.forCron(parser.parse(cronExpression));
-                    ZonedDateTime now = ZonedDateTime.now();
-                    Optional<ZonedDateTime> nextExecution = executionTime.nextExecution(now);
-                    for (int i = 0; i < 10; i++) {
-                        if (nextExecution.isPresent()) {
-                            // yyyy-MM-dd HH:mm:ss
-                            LocalDateTime localDateTime = nextExecution.get().toLocalDateTime();
-                            String format = DateUtil.format(localDateTime, "yyyy-MM-dd HH:mm:ss");
-                            nextExecutionTimes.add(format);
-                            nextExecution = executionTime.nextExecution(nextExecution.get());
-                        }
-                    }
+                    List<String> nextExecutionTimes = CronExpressionUtil.nextExecutions(cronExpression, ZonedDateTime.now(), 10)
+                            .stream()
+                            .map(ZonedDateTime::toLocalDateTime)
+                            .map(localDateTime -> DateUtil.format(localDateTime, "yyyy-MM-dd HH:mm:ss"))
+                            .toList();
                     cronForm.getNextExecutionTimeTextArea().setText("最近10次运行时间：\n" + String.join("\n", nextExecutionTimes));
                 } catch (Exception ex) {
                     cronForm.getNextExecutionTimeTextArea().setText("最近10次运行时间：\n" + ex.getMessage());

--- a/src/main/java/com/luoboduner/moo/tool/util/CronExpressionUtil.java
+++ b/src/main/java/com/luoboduner/moo/tool/util/CronExpressionUtil.java
@@ -1,0 +1,76 @@
+package com.luoboduner.moo.tool.util;
+
+import com.cronutils.descriptor.CronDescriptor;
+import com.cronutils.model.Cron;
+import com.cronutils.model.CronType;
+import com.cronutils.model.definition.CronDefinition;
+import com.cronutils.model.definition.CronDefinitionBuilder;
+import com.cronutils.model.time.ExecutionTime;
+import com.cronutils.parser.CronParser;
+
+import java.time.ZonedDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+
+public class CronExpressionUtil {
+
+    private CronExpressionUtil() {
+    }
+
+    public static String describe(String cronExpression, Locale locale) {
+        CronDescriptor descriptor = CronDescriptor.instance(locale);
+        return descriptor.describe(parse(cronExpression));
+    }
+
+    public static List<ZonedDateTime> nextExecutions(String cronExpression, ZonedDateTime startTime, int count) {
+        List<ZonedDateTime> nextExecutionTimes = new ArrayList<>();
+        if (count <= 0) {
+            return nextExecutionTimes;
+        }
+
+        ExecutionTime executionTime = ExecutionTime.forCron(parse(cronExpression));
+        Optional<ZonedDateTime> nextExecution = executionTime.nextExecution(startTime);
+        for (int i = 0; i < count && nextExecution.isPresent(); i++) {
+            ZonedDateTime execution = nextExecution.get();
+            nextExecutionTimes.add(execution);
+            nextExecution = executionTime.nextExecution(execution);
+        }
+        return nextExecutionTimes;
+    }
+
+    public static Cron parse(String cronExpression) {
+        String normalizedCronExpression = normalize(cronExpression);
+        CronDefinition cronDefinition = CronDefinitionBuilder.instanceDefinitionFor(resolveCronType(normalizedCronExpression));
+        CronParser parser = new CronParser(cronDefinition);
+        return parser.parse(normalizedCronExpression);
+    }
+
+    private static CronType resolveCronType(String cronExpression) {
+        if (cronExpression.startsWith("@")) {
+            return CronType.UNIX;
+        }
+
+        int fieldCount = cronExpression.split("\\s+").length;
+        if (fieldCount == 5) {
+            return CronType.UNIX;
+        }
+        if (fieldCount == 6 || fieldCount == 7) {
+            return CronType.QUARTZ;
+        }
+        throw new IllegalArgumentException("Cron表达式格式错误，仅支持Linux 5段或Quartz 6/7段表达式");
+    }
+
+    private static String normalize(String cronExpression) {
+        if (cronExpression == null) {
+            throw new IllegalArgumentException("Cron表达式不能为空");
+        }
+
+        String normalizedCronExpression = cronExpression.trim();
+        if (normalizedCronExpression.isEmpty()) {
+            throw new IllegalArgumentException("Cron表达式不能为空");
+        }
+        return normalizedCronExpression;
+    }
+}

--- a/src/test/java/com/luoboduner/moo/tool/util/CronExpressionUtilTest.java
+++ b/src/test/java/com/luoboduner/moo/tool/util/CronExpressionUtilTest.java
@@ -1,0 +1,43 @@
+package com.luoboduner.moo.tool.util;
+
+import org.junit.Test;
+
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.Locale;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+public class CronExpressionUtilTest {
+
+    private static final ZoneId ZONE_ID = ZoneId.of("Asia/Shanghai");
+
+    @Test
+    public void shouldCalculateNextExecutionsForUnixCron() {
+        ZonedDateTime now = ZonedDateTime.of(2026, 6, 3, 10, 1, 30, 0, ZONE_ID);
+
+        List<ZonedDateTime> nextExecutionTimes = CronExpressionUtil.nextExecutions("*/5 * * * *", now, 3);
+
+        assertEquals(ZonedDateTime.of(2026, 6, 3, 10, 5, 0, 0, ZONE_ID), nextExecutionTimes.get(0));
+        assertEquals(ZonedDateTime.of(2026, 6, 3, 10, 10, 0, 0, ZONE_ID), nextExecutionTimes.get(1));
+        assertEquals(ZonedDateTime.of(2026, 6, 3, 10, 15, 0, 0, ZONE_ID), nextExecutionTimes.get(2));
+    }
+
+    @Test
+    public void shouldKeepQuartzCronCompatibility() {
+        ZonedDateTime now = ZonedDateTime.of(2026, 6, 3, 11, 59, 0, 0, ZONE_ID);
+
+        List<ZonedDateTime> nextExecutionTimes = CronExpressionUtil.nextExecutions("0 0 12 * * ?", now, 1);
+
+        assertEquals(ZonedDateTime.of(2026, 6, 3, 12, 0, 0, 0, ZONE_ID), nextExecutionTimes.get(0));
+    }
+
+    @Test
+    public void shouldDescribeUnixCron() {
+        String description = CronExpressionUtil.describe("*/5 * * * *", Locale.ENGLISH);
+
+        assertFalse(description.isBlank());
+    }
+}


### PR DESCRIPTION
## 变更说明
- 新增 Cron 表达式统一解析工具，按字段数自动识别 Linux 5 段 Cron 和 Quartz 6/7 段 Cron
- Cron 主面板的自然语言描述、最近 10 次运行时间改为复用统一解析逻辑
- 收藏 Cron 弹窗同步支持 Linux Cron 表达式描述
- 补充 Linux Cron 与 Quartz Cron 的兼容性单元测试

## 解决的问题
解决 #156

## 测试
- `mvn -q test`
