### PR TITLE
feat: add macOS native SwiftUI preview skeleton

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,5 +31,10 @@ build/
 ### VS Code ###
 .vscode/
 
+docs
+
 
 logs/
+
+.codegraph
+.cursor

--- a/macos/.gitignore
+++ b/macos/.gitignore
@@ -1,0 +1,2 @@
+.build/
+.swiftpm/

--- a/macos/Package.swift
+++ b/macos/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version: 5.9
+
+import PackageDescription
+
+let package = Package(
+    name: "MooToolNative",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .executable(name: "MooToolNative", targets: ["MooToolNativeApp"]),
+        .library(name: "MooToolNativeCore", targets: ["MooToolNativeCore"])
+    ],
+    targets: [
+        .target(name: "MooToolNativeCore"),
+        .executableTarget(
+            name: "MooToolNativeApp",
+            dependencies: ["MooToolNativeCore"]
+        ),
+        .testTarget(
+            name: "MooToolNativeCoreTests",
+            dependencies: ["MooToolNativeCore"]
+        )
+    ]
+)

--- a/macos/README.md
+++ b/macos/README.md
@@ -1,0 +1,33 @@
+# MooTool Native for macOS
+
+This directory contains the preview skeleton for a macOS-native MooTool app built with SwiftUI. Open `Package.swift` in Xcode to work on the app as a native macOS project.
+
+The current Java/Swing application remains the stable cross-platform implementation. This native app is intentionally small: it provides the project structure, a minimal SwiftUI shell, settings, and tests for the top-level module catalog. It does not replace the existing macOS Java DMG.
+
+## Requirements
+
+- macOS 14 or later
+- Xcode 15 or later for tests and app development
+- Swift 5.9 compatible command line tools for basic package builds
+
+## Local Build
+
+```bash
+cd macos
+swift build
+```
+
+When full Xcode is available and its license has been accepted:
+
+```bash
+cd macos
+swift test
+swift run MooToolNative
+```
+
+## Migration Direction
+
+- Keep Windows and Linux on the existing Java build.
+- Keep the Java macOS package available while this native app is incomplete.
+- Add native modules in small PRs after the skeleton is accepted.
+- Prefer importing legacy data from `~/.MooTool/MooTool.db` instead of long-term shared writes to the old database.

--- a/macos/Sources/MooToolNativeApp/ContentView.swift
+++ b/macos/Sources/MooToolNativeApp/ContentView.swift
@@ -1,0 +1,15 @@
+import MooToolNativeCore
+import SwiftUI
+
+struct ContentView: View {
+    @State private var selection: MooToolModule? = MooToolModuleCatalog.defaultSelection
+
+    var body: some View {
+        NavigationSplitView {
+            SidebarView(selection: $selection)
+        } detail: {
+            ModuleDetailView(module: selection)
+        }
+        .frame(minWidth: 960, minHeight: 620)
+    }
+}

--- a/macos/Sources/MooToolNativeApp/ModuleDetailView.swift
+++ b/macos/Sources/MooToolNativeApp/ModuleDetailView.swift
@@ -1,0 +1,41 @@
+import MooToolNativeCore
+import SwiftUI
+
+struct ModuleDetailView: View {
+    let module: MooToolModule?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            if let module {
+                Label(module.title, systemImage: module.symbolName)
+                    .font(.title2)
+                    .symbolRenderingMode(.hierarchical)
+
+                Text(statusText(for: module.status))
+                    .foregroundStyle(.secondary)
+
+                Divider()
+
+                Text("原生版预览骨架")
+                    .font(.headline)
+
+                Text("该模块将在骨架通过后分阶段迁移。")
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("请选择模块")
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(28)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+    }
+
+    private func statusText(for status: MooToolModuleStatus) -> String {
+        switch status {
+        case .planned:
+            "计划中"
+        case .preview:
+            "预览"
+        }
+    }
+}

--- a/macos/Sources/MooToolNativeApp/MooToolNativeApp.swift
+++ b/macos/Sources/MooToolNativeApp/MooToolNativeApp.swift
@@ -1,0 +1,36 @@
+import SwiftUI
+
+@main
+struct MooToolNativeApp: App {
+    @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
+    @State private var settings = NativeAppSettings()
+
+    var body: some Scene {
+        WindowGroup("MooTool Native") {
+            ContentView()
+                .environment(settings)
+        }
+        .commands {
+            CommandGroup(replacing: .appInfo) {
+                Button("关于 MooTool Native") {
+                    NSApplication.shared.orderFrontStandardAboutPanel(options: [
+                        .applicationName: "MooTool Native",
+                        .applicationVersion: "Preview"
+                    ])
+                }
+            }
+        }
+
+        Settings {
+            SettingsView()
+                .environment(settings)
+        }
+    }
+}
+
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        NSApplication.shared.setActivationPolicy(.regular)
+        NSApplication.shared.activate()
+    }
+}

--- a/macos/Sources/MooToolNativeApp/NativeAppSettings.swift
+++ b/macos/Sources/MooToolNativeApp/NativeAppSettings.swift
@@ -1,0 +1,7 @@
+import Observation
+
+@Observable
+final class NativeAppSettings {
+    var followsSystemAppearance = true
+    var importsLegacyDataOnFirstLaunch = true
+}

--- a/macos/Sources/MooToolNativeApp/SettingsView.swift
+++ b/macos/Sources/MooToolNativeApp/SettingsView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+
+struct SettingsView: View {
+    @Environment(NativeAppSettings.self) private var settings
+
+    var body: some View {
+        @Bindable var settings = settings
+
+        Form {
+            Toggle("跟随系统外观", isOn: $settings.followsSystemAppearance)
+            Toggle("首次启动导入旧数据", isOn: $settings.importsLegacyDataOnFirstLaunch)
+        }
+        .formStyle(.grouped)
+        .padding(24)
+        .frame(width: 420)
+    }
+}

--- a/macos/Sources/MooToolNativeApp/SidebarView.swift
+++ b/macos/Sources/MooToolNativeApp/SidebarView.swift
@@ -1,0 +1,16 @@
+import MooToolNativeCore
+import SwiftUI
+
+struct SidebarView: View {
+    @Binding var selection: MooToolModule?
+
+    var body: some View {
+        List(MooToolModuleCatalog.previewModules, selection: $selection) { module in
+            Label(module.title, systemImage: module.symbolName)
+                .tag(module)
+        }
+        .navigationTitle("MooTool")
+        .listStyle(.sidebar)
+        .frame(minWidth: 220)
+    }
+}

--- a/macos/Sources/MooToolNativeCore/MooToolModule.swift
+++ b/macos/Sources/MooToolNativeCore/MooToolModule.swift
@@ -1,0 +1,18 @@
+public enum MooToolModuleStatus: String, Sendable {
+    case planned
+    case preview
+}
+
+public struct MooToolModule: Identifiable, Equatable, Hashable, Sendable {
+    public let id: String
+    public let title: String
+    public let symbolName: String
+    public let status: MooToolModuleStatus
+
+    public init(id: String, title: String, symbolName: String, status: MooToolModuleStatus) {
+        self.id = id
+        self.title = title
+        self.symbolName = symbolName
+        self.status = status
+    }
+}

--- a/macos/Sources/MooToolNativeCore/MooToolModuleCatalog.swift
+++ b/macos/Sources/MooToolNativeCore/MooToolModuleCatalog.swift
@@ -1,0 +1,17 @@
+public enum MooToolModuleCatalog {
+    public static let previewModules: [MooToolModule] = [
+        MooToolModule(id: "quick-note", title: "随手记", symbolName: "note.text", status: .planned),
+        MooToolModule(id: "json", title: "JSON", symbolName: "curlybraces", status: .planned),
+        MooToolModule(id: "time", title: "时间转换", symbolName: "clock", status: .planned),
+        MooToolModule(id: "encoding", title: "编码转换", symbolName: "arrow.left.arrow.right", status: .planned),
+        MooToolModule(id: "qr-code", title: "二维码", symbolName: "qrcode", status: .planned),
+        MooToolModule(id: "http", title: "HTTP", symbolName: "network", status: .planned),
+        MooToolModule(id: "host", title: "Host", symbolName: "server.rack", status: .planned),
+        MooToolModule(id: "regex", title: "正则", symbolName: "text.magnifyingglass", status: .planned),
+        MooToolModule(id: "text-diff", title: "文本对比", symbolName: "doc.on.doc", status: .planned)
+    ]
+
+    public static var defaultSelection: MooToolModule? {
+        previewModules.first
+    }
+}

--- a/macos/Tests/MooToolNativeCoreTests/MooToolModuleCatalogTests.swift
+++ b/macos/Tests/MooToolNativeCoreTests/MooToolModuleCatalogTests.swift
@@ -1,0 +1,26 @@
+import XCTest
+@testable import MooToolNativeCore
+
+final class MooToolModuleCatalogTests: XCTestCase {
+    func testPreviewCatalogExposesStableTopLevelModules() {
+        let modules = MooToolModuleCatalog.previewModules
+
+        XCTAssertEqual(modules.map(\.id), [
+            "quick-note",
+            "json",
+            "time",
+            "encoding",
+            "qr-code",
+            "http",
+            "host",
+            "regex",
+            "text-diff"
+        ])
+        XCTAssertEqual(modules.first?.title, "随手记")
+        XCTAssertEqual(modules.first?.status, .planned)
+    }
+
+    func testFirstPreviewModuleIsDefaultSelection() {
+        XCTAssertEqual(MooToolModuleCatalog.defaultSelection?.id, "quick-note")
+    }
+}


### PR DESCRIPTION
## 背景

关联 Discussion：#193

根据维护者在 RFC 中的回复，本 PR 先在当前仓库中新增 `macos/` 子工程，用于探索 macOS 原生 SwiftUI 版本。该版本目前仅作为 preview skeleton，不替换现有 Java/Swing 版本，也不影响 Windows/Linux/macOS 现有 Java 打包流程。

## 变更内容

- 新增 `macos/Package.swift`，提供 Swift Package 形式的 macOS 原生子工程入口。
- 新增最小 SwiftUI App shell：
  - 侧边栏模块列表
  - 模块详情占位页
  - Settings 窗口
  - About 菜单
- 新增 `MooToolNativeCore`，放置可测试的模块目录模型。
- 新增 `MooToolNativeCoreTests`，验证 preview 模块列表和默认选中项。
- 新增 `macos/README.md`，说明 preview 定位、本地构建方式和后续迁移方向。
- 新增 `macos/.gitignore`，忽略 SwiftPM `.build/` 和 `.swiftpm/` 产物。

## 非目标

- 不迁移具体功能模块。
- 不替换当前 macOS Java DMG。
- 不修改现有 Maven/Javapackager 构建。
- 不修改 Windows/Linux 发布链路。

## 验证

```bash
cd macos
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
```

结果：

- `MooToolNativeCoreTests` 通过
- 2 tests, 0 failures

也验证了基础构建：

```bash
cd macos
DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build
```

## 备注

当前 `macos/` 只是原生版骨架。后续如果方向继续被接受，可以按模块分批迁移，并优先保持与现有 Java 版并列发布。
