### PR TITLE
ci(macos): 添加原生预览手动构建

### DIFF
--- a/.github/workflows/macos-native-preview.yml
+++ b/.github/workflows/macos-native-preview.yml
@@ -1,0 +1,29 @@
+name: macOS native preview
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  swift-package:
+    name: Swift package build and test
+    runs-on: macos-14
+    env:
+      DEVELOPER_DIR: /Applications/Xcode.app/Contents/Developer
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Print toolchain versions
+        run: |
+          xcodebuild -version
+          swift --version
+
+      - name: Build native preview
+        run: swift build --package-path macos
+
+      - name: Test native preview
+        run: swift test --package-path macos

--- a/macos/README.md
+++ b/macos/README.md
@@ -10,20 +10,35 @@ The current Java/Swing application remains the stable cross-platform implementat
 - Xcode 15 or later for tests and app development
 - Swift 5.9 compatible command line tools for basic package builds
 
-## Local Build
+## Command Line
 
 ```bash
 cd macos
 swift build
 ```
 
-When full Xcode is available and its license has been accepted:
+When full Xcode is available and its license has been accepted, prefer the Xcode developer directory for tests and local launches:
 
 ```bash
 cd macos
-swift test
-swift run MooToolNative
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift run MooToolNative
 ```
+
+If `swift test` fails because the active developer directory points to Command Line Tools, either prefix the command with `DEVELOPER_DIR` as shown above or switch the active Xcode installation with `xcode-select`.
+
+## Xcode
+
+1. Open `macos/Package.swift` in Xcode.
+2. Select the `MooToolNative` scheme.
+3. Choose My Mac as the run destination.
+4. Run with Product > Run.
+
+The preview currently launches as a Swift Package executable. It is not a signed `.app` bundle and is not part of the release DMG pipeline.
+
+## GitHub Actions
+
+The `macOS native preview` workflow builds and tests this Swift Package on `macos-14`. It is intentionally separate from `Build installers`, so the existing Java-based Windows, Linux, and macOS installer jobs remain unchanged.
 
 ## Migration Direction
 


### PR DESCRIPTION
## Summary
- 新增独立的 `macOS native preview` GitHub Actions workflow，仅通过 `workflow_dispatch` 手动触发。
- workflow 在 `macos-14` 上执行 Swift Package 的 `swift build --package-path macos` 和 `swift test --package-path macos`。
- 补充 `macos/README.md` 中命令行、Xcode 启动和 GitHub Actions 说明。

## Scope
- 不修改现有 Java/Swing 主应用。
- 不修改 `Build installers` workflow。
- 不影响 Windows/Linux，也不替换当前 Java macOS DMG。

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path macos`：2 tests, 0 failures。
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --package-path macos`：build complete。
- `ruby -e 'require \"yaml\"; YAML.load_file(\".github/workflows/macos-native-preview.yml\"); puts \"yaml ok\"'`：yaml ok。