### PR TITLE
feat(macos): 添加原生时间转换预览

### DIFF
--- a/macos/Sources/MooToolNativeApp/ModuleDetailView.swift
+++ b/macos/Sources/MooToolNativeApp/ModuleDetailView.swift
@@ -16,11 +16,15 @@ struct ModuleDetailView: View {
 
                 Divider()
 
-                Text("原生版预览骨架")
-                    .font(.headline)
+                if module.id == "time" {
+                    TimeConverterView()
+                } else {
+                    Text("原生版预览骨架")
+                        .font(.headline)
 
-                Text("该模块将在骨架通过后分阶段迁移。")
-                    .foregroundStyle(.secondary)
+                    Text("该模块将在骨架通过后分阶段迁移。")
+                        .foregroundStyle(.secondary)
+                }
             } else {
                 Text("请选择模块")
                     .foregroundStyle(.secondary)

--- a/macos/Sources/MooToolNativeApp/TimeConverterView.swift
+++ b/macos/Sources/MooToolNativeApp/TimeConverterView.swift
@@ -1,0 +1,78 @@
+import MooToolNativeCore
+import SwiftUI
+
+struct TimeConverterView: View {
+    @State private var timestampInput = String(TimeConversionService.currentTimestamp().seconds)
+    @State private var errorMessage: String?
+
+    private var conversionResult: TimeConversionResult? {
+        do {
+            return try TimeConversionService.convertTimestamp(timestampInput)
+        } catch {
+            return nil
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 18) {
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Unix 时间戳")
+                    .font(.headline)
+                HStack(spacing: 10) {
+                    TextField("输入秒或毫秒时间戳", text: $timestampInput)
+                        .textFieldStyle(.roundedBorder)
+                        .font(.system(.body, design: .monospaced))
+                        .onChange(of: timestampInput) {
+                            errorMessage = nil
+                        }
+
+                    Button("当前时间") {
+                        let current = TimeConversionService.currentTimestamp()
+                        timestampInput = String(current.seconds)
+                        errorMessage = nil
+                    }
+                }
+            }
+
+            if let conversionResult {
+                resultGrid(conversionResult)
+            } else {
+                ContentUnavailableView("无法解析时间戳", systemImage: "exclamationmark.triangle", description: Text(errorMessage ?? "请输入 Unix 秒或毫秒时间戳。"))
+                    .frame(maxWidth: .infinity, minHeight: 220)
+            }
+
+            Spacer(minLength: 0)
+        }
+    }
+
+    private func resultGrid(_ result: TimeConversionResult) -> some View {
+        Grid(alignment: .leading, horizontalSpacing: 18, verticalSpacing: 14) {
+            resultRow(title: "本地时间", value: result.formattedText)
+            resultRow(title: "秒", value: String(result.seconds))
+            resultRow(title: "毫秒", value: String(result.milliseconds))
+        }
+        .padding(16)
+        .background(.background.secondary, in: RoundedRectangle(cornerRadius: 8))
+    }
+
+    private func resultRow(title: String, value: String) -> some View {
+        GridRow {
+            Text(title)
+                .foregroundStyle(.secondary)
+                .frame(width: 72, alignment: .leading)
+
+            Text(value)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
+
+            Button {
+                NSPasteboard.general.clearContents()
+                NSPasteboard.general.setString(value, forType: .string)
+            } label: {
+                Image(systemName: "doc.on.doc")
+            }
+            .buttonStyle(.borderless)
+            .help("复制")
+        }
+    }
+}

--- a/macos/Sources/MooToolNativeCore/MooToolModuleCatalog.swift
+++ b/macos/Sources/MooToolNativeCore/MooToolModuleCatalog.swift
@@ -2,7 +2,7 @@ public enum MooToolModuleCatalog {
     public static let previewModules: [MooToolModule] = [
         MooToolModule(id: "quick-note", title: "随手记", symbolName: "note.text", status: .planned),
         MooToolModule(id: "json", title: "JSON", symbolName: "curlybraces", status: .planned),
-        MooToolModule(id: "time", title: "时间转换", symbolName: "clock", status: .planned),
+        MooToolModule(id: "time", title: "时间转换", symbolName: "clock", status: .preview),
         MooToolModule(id: "encoding", title: "编码转换", symbolName: "arrow.left.arrow.right", status: .planned),
         MooToolModule(id: "qr-code", title: "二维码", symbolName: "qrcode", status: .planned),
         MooToolModule(id: "http", title: "HTTP", symbolName: "network", status: .planned),

--- a/macos/Sources/MooToolNativeCore/TimeConversionService.swift
+++ b/macos/Sources/MooToolNativeCore/TimeConversionService.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+public enum TimeConversionError: Error, Equatable, Sendable {
+    case emptyInput
+    case invalidTimestamp
+}
+
+public struct TimestampPair: Equatable, Sendable {
+    public let seconds: Int64
+    public let milliseconds: Int64
+}
+
+public struct TimeConversionResult: Equatable, Sendable {
+    public let seconds: Int64
+    public let milliseconds: Int64
+    public let formattedText: String
+}
+
+public enum TimeConversionService {
+    public static func convertTimestamp(_ rawValue: String, timeZone: TimeZone = .current) throws -> TimeConversionResult {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else {
+            throw TimeConversionError.emptyInput
+        }
+
+        guard let parsedValue = Int64(value), isIntegerLiteral(value) else {
+            throw TimeConversionError.invalidTimestamp
+        }
+
+        let digitCount = value.trimmingPrefix("-").count
+        let milliseconds: Int64
+        let seconds: Int64
+
+        if digitCount > 10 {
+            milliseconds = parsedValue
+            seconds = parsedValue / 1_000
+        } else {
+            let multiplied = parsedValue.multipliedReportingOverflow(by: 1_000)
+            guard !multiplied.overflow else {
+                throw TimeConversionError.invalidTimestamp
+            }
+            seconds = parsedValue
+            milliseconds = multiplied.partialValue
+        }
+
+        let date = Date(timeIntervalSince1970: Double(seconds))
+        return TimeConversionResult(
+            seconds: seconds,
+            milliseconds: milliseconds,
+            formattedText: format(date: date, milliseconds: millisecondComponent(from: milliseconds), timeZone: timeZone)
+        )
+    }
+
+    public static func currentTimestamp(now: Date = Date()) -> TimestampPair {
+        let milliseconds = Int64((now.timeIntervalSince1970 * 1_000).rounded())
+        return TimestampPair(seconds: milliseconds / 1_000, milliseconds: milliseconds)
+    }
+
+    private static func isIntegerLiteral(_ value: String) -> Bool {
+        let startIndex = value.first == "-" ? value.index(after: value.startIndex) : value.startIndex
+        guard startIndex < value.endIndex else {
+            return false
+        }
+        return value[startIndex...].allSatisfy(\.isNumber)
+    }
+
+    private static func millisecondComponent(from milliseconds: Int64) -> Int64 {
+        let component = milliseconds % 1_000
+        return component >= 0 ? component : -component
+    }
+
+    private static func format(date: Date, milliseconds: Int64, timeZone: TimeZone) -> String {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+
+        let components = calendar.dateComponents(
+            [.year, .month, .day, .hour, .minute, .second],
+            from: date
+        )
+        let zoneText = timeZone.secondsFromGMT(for: date) == 0 ? "UTC" : (timeZone.abbreviation(for: date) ?? timeZone.identifier)
+
+        return String(
+            format: "%04d-%02d-%02d %02d:%02d:%02d.%03d %@",
+            components.year ?? 0,
+            components.month ?? 0,
+            components.day ?? 0,
+            components.hour ?? 0,
+            components.minute ?? 0,
+            components.second ?? 0,
+            milliseconds,
+            zoneText
+        )
+    }
+}

--- a/macos/Tests/MooToolNativeCoreTests/MooToolModuleCatalogTests.swift
+++ b/macos/Tests/MooToolNativeCoreTests/MooToolModuleCatalogTests.swift
@@ -23,4 +23,10 @@ final class MooToolModuleCatalogTests: XCTestCase {
     func testFirstPreviewModuleIsDefaultSelection() {
         XCTAssertEqual(MooToolModuleCatalog.defaultSelection?.id, "quick-note")
     }
+
+    func testTimeModuleIsMarkedAsPreview() {
+        let timeModule = MooToolModuleCatalog.previewModules.first { $0.id == "time" }
+
+        XCTAssertEqual(timeModule?.status, .preview)
+    }
 }

--- a/macos/Tests/MooToolNativeCoreTests/TimeConversionServiceTests.swift
+++ b/macos/Tests/MooToolNativeCoreTests/TimeConversionServiceTests.swift
@@ -1,0 +1,45 @@
+import XCTest
+@testable import MooToolNativeCore
+
+final class TimeConversionServiceTests: XCTestCase {
+    func testConvertsUnixSecondsTimestamp() throws {
+        let result = try TimeConversionService.convertTimestamp("1704067200", timeZone: utcTimeZone)
+
+        XCTAssertEqual(result.seconds, 1_704_067_200)
+        XCTAssertEqual(result.milliseconds, 1_704_067_200_000)
+        XCTAssertEqual(result.formattedText, "2024-01-01 00:00:00.000 UTC")
+    }
+
+    func testConvertsUnixMillisecondsTimestamp() throws {
+        let result = try TimeConversionService.convertTimestamp("1704067200123", timeZone: utcTimeZone)
+
+        XCTAssertEqual(result.seconds, 1_704_067_200)
+        XCTAssertEqual(result.milliseconds, 1_704_067_200_123)
+        XCTAssertEqual(result.formattedText, "2024-01-01 00:00:00.123 UTC")
+    }
+
+    func testCurrentTimestampUsesProvidedDate() {
+        let timestamp = TimeConversionService.currentTimestamp(
+            now: Date(timeIntervalSince1970: 1_704_067_200.123)
+        )
+
+        XCTAssertEqual(timestamp.seconds, 1_704_067_200)
+        XCTAssertEqual(timestamp.milliseconds, 1_704_067_200_123)
+    }
+
+    func testRejectsEmptyTimestamp() {
+        XCTAssertThrowsError(try TimeConversionService.convertTimestamp("   ", timeZone: utcTimeZone)) { error in
+            XCTAssertEqual(error as? TimeConversionError, .emptyInput)
+        }
+    }
+
+    func testRejectsInvalidTimestamp() {
+        XCTAssertThrowsError(try TimeConversionService.convertTimestamp("not-a-time", timeZone: utcTimeZone)) { error in
+            XCTAssertEqual(error as? TimeConversionError, .invalidTimestamp)
+        }
+    }
+
+    private var utcTimeZone: TimeZone {
+        TimeZone(secondsFromGMT: 0)!
+    }
+}


### PR DESCRIPTION
## Summary
- 为 macOS SwiftUI 原生预览版新增第一个可用工具页：时间转换。
- 新增 `TimeConversionService`，支持 Unix 秒/毫秒时间戳解析、格式化展示，以及当前时间戳生成。
- 将目录中的“时间转换”标记为 `preview`，并在 SwiftUI detail 区展示输入、结果和复制操作。

## Scope
- 仅修改 `macos/` Swift Package。
- 不修改 Java/Swing 主应用。
- 不修改现有 Windows/Linux/macOS Java 安装包发布链。

## Validation
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift test --package-path macos`：8 tests, 0 failures。
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer swift build --package-path macos`：build complete。

## Notes
- 这是 macOS 原生路线中第一个真实功能迁移示例，功能范围刻意保持小而独立，便于后续按工具逐步迁移。