### PR TITLE
feat：JSON 工具增加新建文件夹快捷入口

### DIFF
--- a/src/main/java/com/luoboduner/moo/tool/ui/form/func/JsonBeautyForm.java
+++ b/src/main/java/com/luoboduner/moo/tool/ui/form/func/JsonBeautyForm.java
@@ -62,6 +62,7 @@ public class JsonBeautyForm {
     private JComboBox<JsonBeautyListSortMode> listSortComboBox;
     private JButton deleteButton;
     private JButton saveButton;
+    private JButton newFolderButton;
     private JSplitPane splitPane;
     private JButton addButton;
     private JButton findButton;
@@ -165,6 +166,9 @@ public class JsonBeautyForm {
         saveButton = new JButton();
         saveButton.setText("");
         saveButton.setToolTipText("保存(Ctrl+S)");
+        newFolderButton = new JButton();
+        newFolderButton.setText("");
+        newFolderButton.setToolTipText("新建文件夹");
         deleteButton = new JButton();
         deleteButton.setText("");
         deleteButton.setToolTipText("删除");
@@ -194,6 +198,7 @@ public class JsonBeautyForm {
         actionToolBar = new JToolBar();
         ToolbarUiUtil.configure(actionToolBar);
         actionToolBar.add(addButton);
+        actionToolBar.add(newFolderButton);
         actionToolBar.add(findButton);
         actionToolBar.add(saveButton);
         ToolbarUiUtil.addGroupSeparator(actionToolBar);
@@ -246,6 +251,7 @@ public class JsonBeautyForm {
         I18nUiUtil.setToolTip(fontSizeComboBox, "quickNote.tooltip.fontSize");
         I18nUiUtil.setToolTip(wrapButton, "quickNote.tooltip.wrap");
         I18nUiUtil.setToolTip(addButton, "quickNote.tooltip.new");
+        I18nUiUtil.setToolTip(newFolderButton, "quickNote.newFolder");
         I18nUiUtil.setToolTip(findButton, "quickNote.tooltip.find");
         I18nUiUtil.setToolTip(saveButton, "quickNote.tooltip.save");
         I18nUiUtil.setToolTip(deleteButton, "quickNote.tooltip.delete");
@@ -291,6 +297,7 @@ public class JsonBeautyForm {
         jsonBeautyForm.getSearchTextField().putClientProperty(FlatClientProperties.PLACEHOLDER_TEXT, "搜索");
 
         jsonBeautyForm.getAddButton().setIcon(new FlatSVGIcon("icon/add.svg"));
+        jsonBeautyForm.getNewFolderButton().setIcon(new FlatSVGIcon("icon/folder-add.svg"));
         jsonBeautyForm.getFindButton().setIcon(new FlatSVGIcon("icon/find.svg"));
         jsonBeautyForm.getSaveButton().setIcon(new FlatSVGIcon("icon/save.svg"));
         jsonBeautyForm.getBeautifyButton().setIcon(new FlatSVGIcon("icon/json.svg"));

--- a/src/main/java/com/luoboduner/moo/tool/ui/listener/func/JsonBeautyListener.java
+++ b/src/main/java/com/luoboduner/moo/tool/ui/listener/func/JsonBeautyListener.java
@@ -575,6 +575,7 @@ public class JsonBeautyListener {
         }
 
         newFileMenuItem.addActionListener(e -> newJson());
+        jsonBeautyForm.getNewFolderButton().addActionListener(e -> createFolder(jsonBeautyForm));
         newFolderMenuItem.addActionListener(e -> createFolder(jsonBeautyForm));
         renameMenuItem.addActionListener(e -> renameSelectedItem(jsonBeautyForm));
         deleteMenuItem.addActionListener(e -> deleteFiles(jsonBeautyForm));

--- a/src/main/resources/icon/folder-add.svg
+++ b/src/main/resources/icon/folder-add.svg
@@ -1,0 +1,1 @@
+<?xml version="1.0" encoding="UTF-8"?><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="#cdcdcd" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 7a2 2 0 0 1 2-2h5l2 2h7a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2Z"/><path d="M12 13h6"/><path d="M15 10v6"/></svg>

--- a/src/test/java/com/luoboduner/moo/tool/ui/form/func/JsonBeautyFormTest.java
+++ b/src/test/java/com/luoboduner/moo/tool/ui/form/func/JsonBeautyFormTest.java
@@ -1,0 +1,19 @@
+package com.luoboduner.moo.tool.ui.form.func;
+
+import org.junit.jupiter.api.Test;
+
+import javax.swing.JButton;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class JsonBeautyFormTest {
+
+    @Test
+    public void exposesNewFolderToolbarButton() throws Exception {
+        Field field = JsonBeautyForm.class.getDeclaredField("newFolderButton");
+
+        assertEquals(JButton.class, field.getType());
+        assertEquals(JButton.class, JsonBeautyForm.class.getMethod("getNewFolderButton").getReturnType());
+    }
+}


### PR DESCRIPTION
## 变更说明

- 在 JSON 工具栏增加“新建文件夹”按钮，复用已有的文件夹创建逻辑
- 新增 folder-add SVG 图标
- 增加测试覆盖，确认 JSON 表单暴露新建文件夹按钮入口

## 验证

- `JAVA_HOME=/Users/huapai/Library/Java/JavaVirtualMachines/corretto-21.0.11/Contents/Home /opt/homebrew/Cellar/mvnd/2.0.0-rc-3/libexec/mvn/bin/mvn -Dtest=JsonBeautyFormTest test`
- 本地启动应用检查 JSON 工具栏入口

Closes #168