### PR TITLE
fix: 修复页面卡顿问题

### DIFF
--- a/src/main/java/com/luoboduner/moo/tool/util/JsonBeautyAutoGitScheduler.java
+++ b/src/main/java/com/luoboduner/moo/tool/util/JsonBeautyAutoGitScheduler.java
@@ -5,11 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.SwingWorker;
-import javax.swing.Timer;
 import java.awt.AWTEvent;
 import java.awt.Toolkit;
 import java.awt.event.WindowEvent;
 import java.io.File;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * JSON Vault 空闲 / 失焦后触发 Git 检查点。
@@ -23,10 +25,10 @@ public final class JsonBeautyAutoGitScheduler {
     private static volatile long windowDeactivatedAt;
     private static volatile long lastIdleCheckpointForActivity;
     private static volatile long lastInactiveCheckpointAt;
-    private static Timer tickTimer;
     private static boolean started;
     private static volatile boolean checkpointInProgress;
     private static java.awt.event.AWTEventListener windowListener;
+    private static ScheduledExecutorService scheduler;
 
     private JsonBeautyAutoGitScheduler() {
     }
@@ -36,16 +38,33 @@ public final class JsonBeautyAutoGitScheduler {
             return;
         }
         started = true;
-        tickTimer = new Timer(TICK_MS, e -> evaluateCheckpoint());
-        tickTimer.setRepeats(true);
-        tickTimer.start();
+        scheduler= Executors.newSingleThreadScheduledExecutor(r -> {
+            Thread thread = new Thread(r, "JsonBeautyAutoGitScheduler");
+            thread.setDaemon(true);
+            return thread;
+        });
+        scheduler.scheduleWithFixedDelay(()->{
+            try {
+                evaluateCheckpoint();
+            } catch (Throwable ex) {
+                log.debug("JSON auto git checkpoint failed: {}", ex.getMessage());
+            }
+        },TICK_MS,TICK_MS, TimeUnit.MILLISECONDS);
         attachWindowListener();
     }
 
     public static void stop() {
-        if (tickTimer != null) {
-            tickTimer.stop();
-            tickTimer = null;
+        if(scheduler !=null){
+            scheduler.shutdown();
+            try {
+                if(!scheduler.awaitTermination(TICK_MS,TimeUnit.MILLISECONDS)){
+                    scheduler.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                scheduler.shutdownNow();
+            }finally {
+                scheduler=null;
+            }
         }
         detachWindowListener();
         checkpointInProgress = false;

--- a/src/main/java/com/luoboduner/moo/tool/util/JsonBeautyAutoPullScheduler.java
+++ b/src/main/java/com/luoboduner/moo/tool/util/JsonBeautyAutoPullScheduler.java
@@ -6,8 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.SwingWorker;
-import javax.swing.Timer;
 import java.io.File;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * JSON Vault 后台定时从远程拉取更新。
@@ -19,8 +21,8 @@ public final class JsonBeautyAutoPullScheduler {
 
     private static volatile long lastPullAt;
     private static volatile boolean pullInProgress;
-    private static Timer tickTimer;
     private static boolean started;
+    private static ScheduledExecutorService scheduler;
 
     private JsonBeautyAutoPullScheduler() {
     }
@@ -31,15 +33,32 @@ public final class JsonBeautyAutoPullScheduler {
         }
         started = true;
         lastPullAt = System.currentTimeMillis();
-        tickTimer = new Timer(TICK_MS, e -> evaluatePull());
-        tickTimer.setRepeats(true);
-        tickTimer.start();
+        scheduler= Executors.newSingleThreadScheduledExecutor(r->{
+            Thread thread = new Thread(r, "JsonBeautyAutoPullScheduler");
+            thread.setDaemon(true);
+            return thread;
+        });
+        scheduler.scheduleWithFixedDelay(()->{
+            try {
+                evaluatePull();
+            }catch (Throwable ex){
+                log.debug("JSON auto git pull failed: {}", ex.getMessage());
+            }
+        },TICK_MS,TICK_MS, TimeUnit.MILLISECONDS);
     }
 
     public static void stop() {
-        if (tickTimer != null) {
-            tickTimer.stop();
-            tickTimer = null;
+        if(scheduler !=null){
+            scheduler.shutdown();
+            try {
+                if(!scheduler.awaitTermination(TICK_MS,TimeUnit.MILLISECONDS)){
+                    scheduler.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                scheduler.shutdownNow();
+            }finally {
+                scheduler=null;
+            }
         }
         started = false;
         pullInProgress = false;

--- a/src/main/java/com/luoboduner/moo/tool/util/QuickNoteAutoGitScheduler.java
+++ b/src/main/java/com/luoboduner/moo/tool/util/QuickNoteAutoGitScheduler.java
@@ -5,11 +5,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.SwingWorker;
-import javax.swing.Timer;
 import java.awt.AWTEvent;
 import java.awt.Toolkit;
 import java.awt.event.WindowEvent;
 import java.io.File;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 空闲 / 失焦后触发 Git 检查点（对标 Tolaria useAutoGit）。
@@ -23,10 +25,10 @@ public final class QuickNoteAutoGitScheduler {
     private static volatile long windowDeactivatedAt;
     private static volatile long lastIdleCheckpointForActivity;
     private static volatile long lastInactiveCheckpointAt;
-    private static Timer tickTimer;
     private static boolean started;
     private static volatile boolean checkpointInProgress;
     private static java.awt.event.AWTEventListener windowListener;
+    private static ScheduledExecutorService scheduler;
 
     private QuickNoteAutoGitScheduler() {
     }
@@ -36,16 +38,33 @@ public final class QuickNoteAutoGitScheduler {
             return;
         }
         started = true;
-        tickTimer = new Timer(TICK_MS, e -> evaluateCheckpoint());
-        tickTimer.setRepeats(true);
-        tickTimer.start();
+        scheduler= Executors.newSingleThreadScheduledExecutor(r->{
+            Thread thread = new Thread(r, "QuickNoteAutoGitScheduler");
+            thread.setDaemon(true);
+            return thread;
+        });
+        scheduler.scheduleWithFixedDelay(()->{
+            try {
+                evaluateCheckpoint();
+            }catch (Throwable ex){
+                log.debug("Auto git checkpoint failed: {}", ex.getMessage());
+            }
+        },TICK_MS,TICK_MS, TimeUnit.MILLISECONDS);
         attachWindowListener();
     }
 
     public static void stop() {
-        if (tickTimer != null) {
-            tickTimer.stop();
-            tickTimer = null;
+        if (scheduler != null) {
+            scheduler.shutdown();
+            try {
+                if(!scheduler.awaitTermination(TICK_MS,TimeUnit.MILLISECONDS)){
+                    scheduler.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                scheduler.shutdownNow();
+            }finally {
+                scheduler=null;
+            }
         }
         detachWindowListener();
         checkpointInProgress = false;

--- a/src/main/java/com/luoboduner/moo/tool/util/QuickNoteAutoPullScheduler.java
+++ b/src/main/java/com/luoboduner/moo/tool/util/QuickNoteAutoPullScheduler.java
@@ -6,8 +6,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 
 import javax.swing.SwingWorker;
-import javax.swing.Timer;
 import java.io.File;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 
 /**
  * 后台定时从远程拉取更新（对标 Tolaria useAutoSync）。
@@ -19,8 +21,8 @@ public final class QuickNoteAutoPullScheduler {
 
     private static volatile long lastPullAt;
     private static volatile boolean pullInProgress;
-    private static Timer tickTimer;
     private static boolean started;
+    private static ScheduledExecutorService scheduler;
 
     private QuickNoteAutoPullScheduler() {
     }
@@ -31,15 +33,32 @@ public final class QuickNoteAutoPullScheduler {
         }
         started = true;
         lastPullAt = System.currentTimeMillis();
-        tickTimer = new Timer(TICK_MS, e -> evaluatePull());
-        tickTimer.setRepeats(true);
-        tickTimer.start();
+        scheduler= Executors.newSingleThreadScheduledExecutor(r->{
+            Thread thread = new Thread(r, "QuickNoteAutoPullScheduler");
+            thread.setDaemon(true);
+            return thread;
+        });
+        scheduler.scheduleWithFixedDelay(()->{
+            try{
+                evaluatePull();
+            }catch (Throwable ex){
+                log.debug("Auto git pull failed: {}", ex.getMessage());
+            }
+        },TICK_MS,TICK_MS, TimeUnit.MILLISECONDS);
     }
 
     public static void stop() {
-        if (tickTimer != null) {
-            tickTimer.stop();
-            tickTimer = null;
+        if(scheduler!=null){
+            scheduler.shutdown();
+            try {
+                if(!scheduler.awaitTermination(TICK_MS,TimeUnit.MILLISECONDS)){
+                    scheduler.shutdownNow();
+                }
+            } catch (InterruptedException e) {
+                scheduler.shutdownNow();
+            }finally {
+                scheduler=null;
+            }
         }
         started = false;
         pullInProgress = false;


### PR DESCRIPTION
## 修复页面卡顿
## 原因
swing.Timer 任务执行在EDT线程中，autoGit/autoPul 中使用 swing.Timer 定期执行长耗时的io任务，导致ui无法响应
## 解决
使用ScheduledExecutorService + scheduleWithFixedDelay 替换 swing.Timer